### PR TITLE
Fix MPS-27759 can not find up to date version of maven generator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ group 'org.jetbrains.mps'
 version mpsVersion
 
 task downloadMps(type: de.undercouch.gradle.tasks.download.Download) {
-    src "http://download.jetbrains.com/mps/${mpsMajor.replace(".", "")}/MPS-${mpsVersion}.zip"
+    src "http://download.jetbrains.com/mps/${mpsMajor}/MPS-${mpsVersion}.zip"
     dest "$buildDir/downloads/MPS-${mpsVersion}.zip"
     description "Downloads MPS ${mpsVersion}"
     overwrite false


### PR DESCRIPTION
Changed the URL scheme for downloading MPS